### PR TITLE
EntityService - avoid Path casting if unnecessary (Hibernate v6 issues)

### DIFF
--- a/database-service/src/main/java/info/nino/jpatron/services/entity/EntityService.java
+++ b/database-service/src/main/java/info/nino/jpatron/services/entity/EntityService.java
@@ -979,11 +979,11 @@ public interface EntityService<E>
             Subquery<Long> subquery = null;
 
             //convert filter column to comparison type
-            if(QueryExpression.Filter.booleanComparators.contains(comparator))
+            if(QueryExpression.Filter.booleanComparators.contains(comparator) && !Boolean.class.isAssignableFrom(filterColumn.getJavaType()))
             {
                 cmpFilterColumn = (Expression<? extends T>) filterColumn.as(Boolean.class);
             }
-            else if(comparator == QueryExpression.Filter.Cmp.LIKE)
+            else if(comparator == QueryExpression.Filter.Cmp.LIKE && !String.class.isAssignableFrom(filterColumn.getJavaType()))
             {
                 cmpFilterColumn = (Expression<? extends T>) filterColumn.as(String.class);
             }


### PR DESCRIPTION
Hibernate v6 has much stricter handling of types which leads to issues when casting columns 
 - casted String column type - @Nationalized is not being recognized when filtering (issues with Unicode characters) 
 - casted Boolean column type - omits equals to TRUE in SQL when used with _CriteriaBuilder.isTrue()_ (syntax error in MSSQL)